### PR TITLE
Add gradient color accents to page

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,11 +14,11 @@
       font-family: 'Noto Sans', sans-serif;
       margin: 0;
       padding: 20px;
-      background-color: #f5f5f5;
+      background: linear-gradient(to right, #f5f5f5, #e0f7fa);
     }
 
     nav {
-      background: #333;
+      background: linear-gradient(90deg, #ff7e5f, #feb47b);
       position: sticky;
       top: 0;
       padding: 10px 20px;
@@ -35,11 +35,13 @@
 
     nav a:hover {
       text-decoration: underline;
+      color: #333;
     }
 
     h1 {
       text-align: center;
       margin-bottom: 40px;
+      color: #ff7e5f;
     }
 
     .news-section {
@@ -55,6 +57,7 @@
 
     .card {
       background: white;
+      border-left: 5px solid #ff7e5f;
       border-radius: 10px;
       padding: 20px;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
@@ -62,7 +65,7 @@
     }
 
     .card:hover {
-      background: #007bff;
+      background: linear-gradient(90deg, #ff7e5f, #feb47b);
       color: white;
       transform: translateY(-5px);
     }


### PR DESCRIPTION
## Summary
- restyle body background with gentle gradient
- apply gradient nav bar and add color to links on hover
- accent cards with colored border and gradient hover
- highlight header text with matching color

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68467cc6f2008322aa98d80b34cdf150