### PR TITLE
Add health status page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Test
 
 This repository contains small web examples. `memory-game.html` is a basic memory card matching game built with HTML, CSS, and JavaScript. Open the file in a browser to play.
+
+`health.html` demonstrates loading a JSON file (`data/result.json`) and displaying the results in a table.

--- a/data/result.json
+++ b/data/result.json
@@ -1,0 +1,16 @@
+[
+  {
+    "date": "2025-01-01",
+    "haMatch": true,
+    "contractMatch": true,
+    "backupStatus": "OK",
+    "overallStatus": "Green"
+  },
+  {
+    "date": "2025-01-02",
+    "haMatch": false,
+    "contractMatch": true,
+    "backupStatus": "Warning",
+    "overallStatus": "Yellow"
+  }
+]

--- a/health.html
+++ b/health.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Health Status</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 20px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th, td {
+      padding: 8px 12px;
+      border: 1px solid #ccc;
+      text-align: left;
+    }
+    th {
+      background-color: #f2f2f2;
+    }
+  </style>
+</head>
+<body>
+  <h1>Health Check Results</h1>
+  <table id="result-table">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>HA Match</th>
+        <th>Contract Match</th>
+        <th>Backup Status</th>
+        <th>Overall Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <!-- populated by JavaScript -->
+    </tbody>
+  </table>
+
+  <script>
+    async function loadResults() {
+      try {
+        const response = await fetch('data/result.json');
+        const data = await response.json();
+        const tbody = document.querySelector('#result-table tbody');
+        data.forEach(item => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `
+            <td>${item.date}</td>
+            <td>${item.haMatch ? 'Yes' : 'No'}</td>
+            <td>${item.contractMatch ? 'Yes' : 'No'}</td>
+            <td>${item.backupStatus}</td>
+            <td>${item.overallStatus}</td>
+          `;
+          tbody.appendChild(tr);
+        });
+      } catch (e) {
+        console.error('Failed to load result.json', e);
+      }
+    }
+
+    window.addEventListener('DOMContentLoaded', loadResults);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `health.html` to show health status table
- add sample data in `data/result.json`
- document the new page in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68471b39a3e0832291a34e314477cc42